### PR TITLE
Specifying ‘now()’ as a default value doesn’t work properly on SQLite

### DIFF
--- a/application/models/System_setup_model.php
+++ b/application/models/System_setup_model.php
@@ -160,10 +160,11 @@ class System_setup_model extends CI_Model
                     ),
                     'created' => array(
                         'type' => 'TIMESTAMP',
-                        'default' => 'now()'
+                        'default' => "datetime('now', localtime)"
                     ),
                     'updated' => array(
-                        'type' => 'TIMESTAMP'
+                        'type' => 'TIMESTAMP',
+                        'default' => "datetime('now', localtime)"
                     ),
                     'deleted' => array(
                         'type' => 'TIMESTAMP',
@@ -186,7 +187,8 @@ class System_setup_model extends CI_Model
                     ),
                     'created' => array(
                         'type' => 'TIMESTAMP',
-                        'default' => 'now()'
+                        'default' => "datetime('now', localtime)"
+
                     ),
                     'updated' => array(
                         'type' => 'TIMESTAMP'
@@ -205,10 +207,11 @@ class System_setup_model extends CI_Model
                     ),
                     'created' => array(
                         'type' => 'TIMESTAMP',
-                        'default' => 'now()'
+                        'default' =>"datetime('now', localtime)"
                     ),
                     'updated' => array(
-                        'type' => 'TIMESTAMP'
+                        'type' => 'TIMESTAMP',
+                        'default' =>"datetime('now', localtime)"
                     ),
                     'deleted' => array(
                         'type' => 'TIMESTAMP',
@@ -227,10 +230,11 @@ class System_setup_model extends CI_Model
                     ),
                     'created' => array(
                         'type' => 'TIMESTAMP',
-                        'default' => 'now()'
+                        'default' =>"datetime('now', localtime)"
                     ),
                     'updated' => array(
-                        'type' => 'TIMESTAMP'
+                        'type' => 'TIMESTAMP',
+                        'default' =>"datetime('now', localtime)"                        
                     ),
                     'deleted' => array(
                         'type' => 'TIMESTAMP',


### PR DESCRIPTION
Need to use the datetime(‘now’, local time) construct to set defaults

Fixes #44