### PR TITLE
Changing the transaction details link to represent new framework

### DIFF
--- a/application/config/pacifica.php
+++ b/application/config/pacifica.php
@@ -27,3 +27,4 @@ $config['debug_enabled'] = TRUE;
 
 $config['metadata_server_base_url'] = str_replace('tcp://', 'http://', getenv('METADATA_PORT'));
 $config['policy_server_base_url'] = str_replace('tcp://', 'http://', getenv('POLICY_PORT'));
+$config['status_server_base_url'] = getenv('STATUS_SITE_NAME') ? getenv('STATUS_SITE_NAME') : "http://status.local";

--- a/application/controllers/Group.php
+++ b/application/controllers/Group.php
@@ -97,7 +97,7 @@ class Group extends Baseline_api_controller
                                            );
         $this->local_resources_folder = $this->config->item('local_resources_folder');
         $this->debug = $this->config->item('debug_enabled');
-
+        $this->status_site_base_url = $this->config->item('status_server_base_url');
     }
 
     /**
@@ -287,6 +287,7 @@ class Group extends Baseline_api_controller
 
         $results = $this->summary->detailed_transaction_list($transaction_list);
         $this->page_data['transaction_info'] = $results;
+        $this->page_data['status_site_base_url'] = $this->status_site_base_url;
 
         $this->load->view('object_types/transaction_details_insert.html', $this->page_data);
 

--- a/application/views/object_types/transaction_details_insert.html
+++ b/application/views/object_types/transaction_details_insert.html
@@ -27,7 +27,7 @@
                 $friendly_file_size = format_bytes($item['bundle_size']);
             ?>
             <tr>
-                <td><a href="/myemsl/status/index.php/status/view/t/<?= $id ?>" target="_blank"><?= $id ?></a></td>
+                <td><a href="<?= $status_site_base_url ?>/view/<?= $id ?>" target="_blank"><?= $id ?></a></td>
                 <td><?= $ul_time->format('m/d/Y g:ia') ?></td>
                 <td><?= $ul_mod_string ?></td>
                 <td><?= array_key_exists('proposal_id',$item) && !empty($item['proposal_id']) ? $item['proposal_id'] : "N/A" ?></td>


### PR DESCRIPTION
The old style 'index.php/status/view/t/<num>' links were deprecated earlier and have been replaced with '/view/<num> styled URLs

Fixes #39 