### PR TITLE
File count graph display fix

### DIFF
--- a/application/resources/scripts/reporting.js
+++ b/application/resources/scripts/reporting.js
@@ -88,7 +88,7 @@ var hc_timeline_options = {
     },
     yAxis: [{ //transaction count axis
         type: 'logarithmic',
-        min: 1,
+        min: 0.1,
         title: {
             text: 'Total File Count',
             style: {


### PR DESCRIPTION
Single files were not showing up on the File count plot due to issues with the logarithmic y-axis. Changing the lower bound to be 0.1 instead of 1 seems to have patched it.

Fixes #38