### PR TITLE
Detailed transaction list code now checks for empty transaction list

### DIFF
--- a/application/controllers/Group.php
+++ b/application/controllers/Group.php
@@ -284,7 +284,7 @@ class Group extends Baseline_api_controller
             $http_raw_post_data = file_get_contents('php://input');
             $transaction_list   = json_decode($http_raw_post_data, TRUE);
         }
-        if($transaction_list){
+        if($transaction_list) {
             $results = $this->summary->detailed_transaction_list($transaction_list);
             $this->page_data['transaction_info'] = $results;
             $this->page_data['status_site_base_url'] = $this->status_site_base_url;

--- a/application/controllers/Group.php
+++ b/application/controllers/Group.php
@@ -284,12 +284,15 @@ class Group extends Baseline_api_controller
             $http_raw_post_data = file_get_contents('php://input');
             $transaction_list   = json_decode($http_raw_post_data, TRUE);
         }
+        if($transaction_list){
+            $results = $this->summary->detailed_transaction_list($transaction_list);
+            $this->page_data['transaction_info'] = $results;
+            $this->page_data['status_site_base_url'] = $this->status_site_base_url;
 
-        $results = $this->summary->detailed_transaction_list($transaction_list);
-        $this->page_data['transaction_info'] = $results;
-        $this->page_data['status_site_base_url'] = $this->status_site_base_url;
-
-        $this->load->view('object_types/transaction_details_insert.html', $this->page_data);
+            $this->load->view('object_types/transaction_details_insert.html', $this->page_data);
+        }else{
+            echo "";
+        }
 
     }
 


### PR DESCRIPTION
If the transaction list used to retrieve a detailed list is empty, just return an empty response, not one with the table headers, etc.