### PR TITLE
Changing the source for our current transaction list

### DIFF
--- a/application/views/object_types/group_pie_scripts_insert.html
+++ b/application/views/object_types/group_pie_scripts_insert.html
@@ -1,10 +1,14 @@
-<?php extract($transaction_info); ?>
+<?php
+    extract($transaction_info);
+    $my_transaction_list = array_unique(call_user_func_array('array_merge', array_values($day_graph['by_date']['transactions_by_day'])));
+    sort($my_transaction_list);
+?>
 <script type="text/javascript">
   $(function () {
     $('#message_container_<?= $group_id ?>').html('<?= $results_message ?>');
     $('#file_count_<?= $group_id ?>').html('<?= $summary_totals["total_file_count"] ?>');
     $('#file_volume_<?= $group_id ?>').html('<?= $summary_totals["total_size_string"] ?>');
-    my_transactions_<?= $group_id ?> = <?= json_encode(array_keys($transaction_info['transaction'])); ?>;
+    my_transactions_<?= $group_id ?> = <?= json_encode($my_transaction_list) ?>;
     transaction_list_<?= $group_id ?> = <?= json_encode($day_graph['by_date']['transactions_by_day']) ?>;
     $('#transaction_details_notifier_<?= $group_id ?>').unbind().click(function(){
       get_transaction_info(this, my_transactions_<?= $group_id ?>);

--- a/application/views/object_types/transaction_details_insert.html
+++ b/application/views/object_types/transaction_details_insert.html
@@ -14,6 +14,7 @@
         </thead>
         <tbody>
             <?php ksort($transaction_info); ?>
+            <?php $user_cache = array(); ?>
             <?php foreach($transaction_info as $id => $item): ?>
             <?php
                 $ul_time = new DateTime($item['upload_datetime']);
@@ -22,7 +23,12 @@
                 $ul_mod_string = $ul_latest_mod->format('m/d/Y') != $ul_earliest_mod->format('m/d/Y') ?
                 "{$ul_earliest_mod->format('m/d/Y')}&ndash;{$ul_latest_mod->format('m/d/Y')}" :
                 $ul_earliest_mod->format('m/d/Y');
-                $ul_user_info = get_user_details($item['uploaded_by_id']);
+                if(!array_key_exists($item['uploaded_by_id'], $user_cache)){
+                    $ul_user_info = get_user_details($item['uploaded_by_id']);
+                    $user_cache[$item['uploaded_by_id']] = $ul_user_info;
+                }else{
+                    $ul_user_info = $user_cache[$item['uploaded_by_id']];
+                }
                 $ul_user = $ul_user_info['simple_display_name'];
                 $friendly_file_size = format_bytes($item['bundle_size']);
             ?>


### PR DESCRIPTION
This removes the need to add back redundant info to the metadata stream

Fixes #80